### PR TITLE
Keep running CI jobs even if the linters fail.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  lint-and-test:
+  run-ci:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
 
@@ -21,5 +20,10 @@ jobs:
     - run: uv sync
 
     - uses: astral-sh/ruff-action@v3
+      continue-on-error: true
+
     - run: ruff format --check --diff
+      continue-on-error: true
+
     - run: uv run pyright
+      continue-on-error: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow job name to "run-ci".
  * Adjusted CI steps to continue running even if certain checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->